### PR TITLE
Ignore naked spies and stubs because they are not dangerous

### DIFF
--- a/lib/rules/no-unrestored-sinon-before-expect.js
+++ b/lib/rules/no-unrestored-sinon-before-expect.js
@@ -52,6 +52,8 @@ module.exports = {
         variableDeclarer.init.callee &&
         variableDeclarer.init.callee.object &&
         variableDeclarer.init.callee.object.name === 'sinon' &&
+        variableDeclarer.init.arguments &&
+        variableDeclarer.init.arguments.length &&
         DANGEROUS_SINON_METHODS.includes(variableDeclarer.init.callee.property.name)
       ) {
         dangerousSinonInstances[variableDeclarer.id.name] = true;

--- a/tests/lib/rules/no-unrestored-sinon-before-expect.js
+++ b/tests/lib/rules/no-unrestored-sinon-before-expect.js
@@ -57,6 +57,24 @@ ruleTester.run('no-unrestored-sinon-before-expect', rule, {
       globals: ['it'],
       parserOptions: { ecmaVersion: 6 },
     },
+    {
+      code: `it("should ignore naked spies", function() {
+        var ajaxSpy = sinon.spy();
+        ajaxSpy();
+        expect(ajaxSpy.callCount).to.equal(1);
+      });`,
+      parserOptions: { ecmaVersion: 6 },
+      globals: ['it'],
+    },
+    {
+      code: `it("should ignore naked stubs", function() {
+        var someStub = sinon.stub();
+        someStub();
+        expect(someStub.callCount).to.equal(1);
+      });`,
+      parserOptions: { ecmaVersion: 6 },
+      globals: ['it'],
+    },
   ],
 
   invalid: [


### PR DESCRIPTION
`const someSpy = sinon.spy()` cannot be restored and isn't at risk of
polluting the test suite. Same deal for `const stub = sinon.stub()`.