### PR TITLE
Fix repeat reports if multiple `expect` expression statements in test

### DIFF
--- a/lib/rules/no-unrestored-sinon-before-expect.js
+++ b/lib/rules/no-unrestored-sinon-before-expect.js
@@ -80,6 +80,7 @@ module.exports = {
         if ({}.hasOwnProperty.call(dangerousSinonInstances, mockName)) {
           const methodName = dangerousSinonInstances[mockName];
           if (methodName !== 'restored') {
+            delete dangerousSinonInstances[mockName];
             const errorData = { node, mockName };
             reportError(errorData);
           }

--- a/tests/lib/rules/no-unrestored-sinon-before-expect.js
+++ b/tests/lib/rules/no-unrestored-sinon-before-expect.js
@@ -158,5 +158,25 @@ ruleTester.run('no-unrestored-sinon-before-expect', rule, {
         },
       ],
     },
+    {
+      code: `it("should report a single once when a test has multiple expects", function() {
+        var ajaxSpy = sinon.spy(AjaxHelpers, 'post');
+        var anotherSpy = sinon.spy(SomeHelper, 'method');
+        anotherSpy.restore();
+        expect(true).to.equal(true);
+        expect(true).to.equal(true);
+        expect(true).to.equal(true);
+        expect(true).to.equal(true);
+        ajaxSpy.restore();
+      });`,
+      parserOptions: { ecmaVersion: 6 },
+      globals: ['it'],
+      errors: [
+        {
+          message: "Call 'ajaxSpy.restore()' before 'expect'",
+          type: 'CallExpression',
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
Deletes the stored sinon methods after reporting so that a single issue won't report once per `expect.