### PR TITLE
Check beforeEach/afterEach hooks for unrestored sinon stubs/spies

### DIFF
--- a/lib/rules/no-unrestored-sinon-before-expect.js
+++ b/lib/rules/no-unrestored-sinon-before-expect.js
@@ -68,20 +68,26 @@ module.exports = {
         node.expression.callee.object.object.callee.name === 'expect';
     }
 
-    function reportError({ node, mockName }) {
+    function reportError({ node, mockName, hook }) {
+      let message;
+      if (hook) {
+        message = `Call '${mockName}.restore()' in an 'afterEach' block`;
+      } else {
+        message = failureMessage(mockName);
+      }
       return context.report({
         node: node.expression,
-        message: failureMessage(mockName),
+        message,
       });
     }
 
-    function verifyAllRestored(node) {
+    function verifyAllRestored(node, hook = false) {
       for (const mockName in dangerousSinonInstances) {
         if ({}.hasOwnProperty.call(dangerousSinonInstances, mockName)) {
           const methodName = dangerousSinonInstances[mockName];
           if (methodName !== 'restored') {
             delete dangerousSinonInstances[mockName];
-            const errorData = { node, mockName };
+            const errorData = { node, mockName, hook };
             reportError(errorData);
           }
         }
@@ -101,48 +107,40 @@ module.exports = {
         node.expression.callee.property.name === 'restore';
     }
 
-    function lintTestHookExpression(bodyBlockNode) {
-      if (bodyBlockNode.type !== 'ExpressionStatement') { return; }
-      const hookMethods = ['beforeEach', 'afterEach'];
-      if (bodyBlockNode.expression && bodyBlockNode.expression.callee
-        && hookMethods.includes(bodyBlockNode.expression.callee.name)) {
-          lintHooks({ args: bodyBlockNode.expression.arguments, hookName: bodyBlockNode.expression.callee.name });
-          verifyAllRestored(bodyBlockNode)
-        }
-    }
-
     function checkForSinonRestore(node) {
       if (node.body && node.body.body && node.body.body.length) {
-        const bodyExpressions = node.body.body
+        const bodyExpressions = node.body.body;
         bodyExpressions.forEach((expression) => {
           if (expression.type === 'ExpressionStatement' && expression.expression
             && expression.expression.callee && expression.expression.callee.object &&
             expression.expression.callee.property && expression.expression.callee.property.name === 'restore'
           ) {
             const sinonVariable = expression.expression.callee.object.name;
-            dangerousSinonInstances[sinonVariable] === 'restored';
+            dangerousSinonInstances[sinonVariable] = 'restored';
           }
         });
       }
+      const fakeNode = { expression: node };
+      return verifyAllRestored(fakeNode, true);
     }
 
     function recordSinonAssignment(node) {
       // this is different from recordSinonInstance because the variable here
       // was already declared outside of the scope of the beforeEach/afterEach
       // block
-        if (node.body && node.body.body && node.body.body.length && node.body.body) {
-          node.body.body.forEach((expressionNode) => {
-            if (!expressionNode.expression && !expressionNode.expression.right
-              && !expressionNode.expression.right.callee && !expressionNode.expression.right.callee.property) { return; }
-            const expression = expressionNode.expression;
+      if (node.body && node.body.body && node.body.body.length && node.body.body) {
+        node.body.body.forEach((expressionNode) => {
+          if (!expressionNode.expression && !expressionNode.expression.right
+            && !expressionNode.expression.right.callee && !expressionNode.expression.right.callee.property) { return; }
+          const expression = expressionNode.expression;
 
-            const sinonMethod = expression.right.callee.property.name;
-            const variableBoundToSinonInstance = expression.left.name;
-            if (DANGEROUS_SINON_METHODS.includes(sinonMethod)) {
-              dangerousSinonInstances[variableBoundToSinonInstance] = true;
-            }
-          });
-        }
+          const sinonMethod = expression.right.callee.property.name;
+          const variableBoundToSinonInstance = expression.left.name;
+          if (DANGEROUS_SINON_METHODS.includes(sinonMethod)) {
+            dangerousSinonInstances[variableBoundToSinonInstance] = true;
+          }
+        });
+      }
     }
 
     function lintHooks({ args, hookName }) {
@@ -156,11 +154,19 @@ module.exports = {
       });
     }
 
+    function lintTestHookExpression(bodyBlockNode) {
+      if (bodyBlockNode.type !== 'ExpressionStatement') { return; }
+      const hookMethods = ['beforeEach', 'afterEach'];
+      if (bodyBlockNode.expression && bodyBlockNode.expression.callee
+        && hookMethods.includes(bodyBlockNode.expression.callee.name)) {
+        lintHooks({ args: bodyBlockNode.expression.arguments, hookName: bodyBlockNode.expression.callee.name });
+      }
+    }
+
     function lintDescribeBlock(expressionArgs) {
       expressionArgs.forEach((arg) => {
         if (!isTestBlock(arg.type)) { return; }
-        const testHookMethods = ['beforeEach', 'afterEach'];
-        const expressionArg= arg.body;
+        const expressionArg = arg.body;
         if (!expressionArg.body.type === 'BlockStatement') { return; }
         const blockBody = expressionArg.body; // this is an array of statements/expressions
         blockBody.forEach((blockStatement) => {

--- a/lib/rules/no-unrestored-sinon-before-expect.js
+++ b/lib/rules/no-unrestored-sinon-before-expect.js
@@ -100,6 +100,76 @@ module.exports = {
         node.expression.callee.property.name === 'restore';
     }
 
+    function lintTestHookExpression(bodyBlockNode) {
+      if (bodyBlockNode.type !== 'ExpressionStatement') { return; }
+      const hookMethods = ['beforeEach', 'afterEach'];
+      if (bodyBlockNode.expression && bodyBlockNode.expression.callee
+        && hookMethods.includes(bodyBlockNode.expression.callee.name)) {
+          lintHooks({ args: bodyBlockNode.expression.arguments, hookName: bodyBlockNode.expression.callee.name });
+          verifyAllRestored(bodyBlockNode)
+        }
+    }
+
+    function checkForSinonRestore(node) {
+      if (node.body && node.body.body && node.body.body.length) {
+        const bodyExpressions = node.body.body
+        bodyExpressions.forEach((expression) => {
+          if (expression.type === 'ExpressionStatement' && expression.expression
+            && expression.expression.callee && expression.expression.callee.object &&
+            expression.expression.callee.property && expression.expression.callee.property.name === 'restore'
+          ) {
+            const sinonVariable = expression.expression.callee.object.name;
+            dangerousSinonInstances[sinonVariable] === 'restored';
+          }
+        });
+      }
+    }
+
+    function recordSinonAssignment(node) {
+      // this is different from recordSinonInstance because the variable here
+      // was already declared outside of the scope of the beforeEach/afterEach
+      // block
+        if (node.body && node.body.body && node.body.body.length && node.body.body) {
+          node.body.body.forEach((expressionNode) => {
+            if (!expressionNode.expression && !expressionNode.expression.right
+              && !expressionNode.expression.right.callee && !expressionNode.expression.right.callee.property) { return; }
+            const expression = expressionNode.expression;
+
+            const sinonMethod = expression.right.callee.property.name;
+            const variableBoundToSinonInstance = expression.left.name;
+            if (DANGEROUS_SINON_METHODS.includes(sinonMethod)) {
+              dangerousSinonInstances[variableBoundToSinonInstance] = true;
+            }
+          });
+        }
+    }
+
+    function lintHooks({ args, hookName }) {
+      args.forEach((arg) => {
+        // see if it is a set or restore,
+        if (hookName === 'beforeEach') {
+          recordSinonAssignment(arg);
+        } else if (hookName === 'afterEach') {
+          checkForSinonRestore(arg);
+        }
+      });
+    }
+
+    function lintDescribeBlock(expressionArgs) {
+      expressionArgs.forEach((arg) => {
+        if (!isTestBlock(arg.type)) { return; }
+        const testHookMethods = ['beforeEach', 'afterEach'];
+        const expressionArg= arg.body;
+        if (!expressionArg.body.type === 'BlockStatement') { return; }
+        const blockBody = expressionArg.body; // this is an array of statements/expressions
+        blockBody.forEach((blockStatement) => {
+          if (blockStatement.type === 'ExpressionStatement') {
+            lintTestHookExpression(blockStatement);
+          }
+        });
+      });
+    }
+
     //----------------------------------------------------------------------
     // Public
     //----------------------------------------------------------------------
@@ -109,6 +179,7 @@ module.exports = {
         if (!node.expression) { return; }
         const callee = node.expression.callee;
         if (!callee) { return; }
+        if (callee.name === 'describe') { lintDescribeBlock(node.expression.arguments); }
         if (callee.name !== 'it') { return; }
 
         const expressionArgs = node.expression.arguments;

--- a/lib/rules/no-unrestored-sinon-before-expect.js
+++ b/lib/rules/no-unrestored-sinon-before-expect.js
@@ -11,14 +11,12 @@
 module.exports = {
   meta: {
     docs: {
-      description: 'no',
-      category: 'Fill me in',
-      recommended: false,
+      description: "Don't forget to clean up your sinon stubs/mocks",
+      category: 'Possible test headache',
+      recommended: true,
     },
-    fixable: null,  // or "code" or "whitespace"
-    schema: [
-      // fill in your schema
-    ],
+    fixable: 'code',  // or "code" or "whitespace", or null
+    schema: [], // no options
   },
 
   create: (context) => {

--- a/tests/lib/rules/no-unrestored-sinon-before-expect.js
+++ b/tests/lib/rules/no-unrestored-sinon-before-expect.js
@@ -14,6 +14,7 @@ const RuleTester = require('eslint').RuleTester;
 // Tests
 //------------------------------------------------------------------------------
 
+const parserOptions = { ecmaVersion: 6 };
 const ruleTester = new RuleTester();
 ruleTester.run('no-unrestored-sinon-before-expect', rule, {
 
@@ -24,8 +25,7 @@ ruleTester.run('no-unrestored-sinon-before-expect', rule, {
         ajaxStub.restore();
         expect(true).to.equal(true);
       });`,
-      globals: ['it'],
-      parserOptions: { ecmaVersion: 6 },
+      parserOptions,
     },
     {
       code: `it("passes with a promise", () => {
@@ -36,8 +36,7 @@ ruleTester.run('no-unrestored-sinon-before-expect', rule, {
           expect(true).to.equal(true);
         })
       });`,
-      globals: ['it'],
-      parserOptions: { ecmaVersion: 6 },
+      parserOptions,
     },
     {
       code: `it("passes with unstub before expect", function() {
@@ -45,8 +44,7 @@ ruleTester.run('no-unrestored-sinon-before-expect', rule, {
         ajaxStub.restore();
         expect(true).to.equal(true);
       });`,
-      globals: ['it'],
-      parserOptions: { ecmaVersion: 6 },
+      parserOptions,
     },
     {
       code: `it("passes when spy is restored before expect", () => {
@@ -54,8 +52,7 @@ ruleTester.run('no-unrestored-sinon-before-expect', rule, {
         ajaxSpy.restore();
         expect(true).to.equal(true);
       });`,
-      globals: ['it'],
-      parserOptions: { ecmaVersion: 6 },
+      parserOptions,
     },
     {
       code: `it("should ignore naked spies", function() {
@@ -63,8 +60,7 @@ ruleTester.run('no-unrestored-sinon-before-expect', rule, {
         ajaxSpy();
         expect(ajaxSpy.callCount).to.equal(1);
       });`,
-      parserOptions: { ecmaVersion: 6 },
-      globals: ['it'],
+      parserOptions,
     },
     {
       code: `it("should ignore naked stubs", function() {
@@ -72,8 +68,7 @@ ruleTester.run('no-unrestored-sinon-before-expect', rule, {
         someStub();
         expect(someStub.callCount).to.equal(1);
       });`,
-      parserOptions: { ecmaVersion: 6 },
-      globals: ['it'],
+      parserOptions,
     },
     {
       code: `describe("passing case with before/after hooks", function() {
@@ -85,8 +80,7 @@ ruleTester.run('no-unrestored-sinon-before-expect', rule, {
           spy.restore();
         });
       });`,
-      parserOptions: { ecmaVersion: 6 },
-      globals: ['it'],
+      parserOptions,
     },
     {
       code: `describe("passes with hooks and it block", function() {
@@ -104,8 +98,7 @@ ruleTester.run('no-unrestored-sinon-before-expect', rule, {
           expect(stub.called).to.equal(true);
         })
       });`,
-      parserOptions: { ecmaVersion: 6 },
-      globals: ['it'],
+      parserOptions,
     },
   ],
 
@@ -116,8 +109,7 @@ ruleTester.run('no-unrestored-sinon-before-expect', rule, {
         expect(true).to.equal(true);
         ajaxStub.restore();
       });`,
-      parserOptions: { ecmaVersion: 6 },
-      globals: ['it'],
+      parserOptions,
       errors: [{
         message: "Call 'ajaxStub.restore()' before 'expect'",
         type: 'CallExpression',
@@ -132,8 +124,7 @@ ruleTester.run('no-unrestored-sinon-before-expect', rule, {
           ajaxStub.restore();
         })
       });`,
-      parserOptions: { ecmaVersion: 6 },
-      globals: ['it'],
+      parserOptions,
       errors: [{
         message: "Call 'ajaxStub.restore()' before 'expect'",
         type: 'CallExpression',
@@ -145,8 +136,7 @@ ruleTester.run('no-unrestored-sinon-before-expect', rule, {
         expect(true).to.equal(true);
         ajaxSpy.restore();
       });`,
-      parserOptions: { ecmaVersion: 6 },
-      globals: ['it'],
+      parserOptions,
       errors: [{
         message: "Call 'ajaxSpy.restore()' before 'expect'",
         type: 'CallExpression',
@@ -160,8 +150,7 @@ ruleTester.run('no-unrestored-sinon-before-expect', rule, {
         ajaxSpy.restore();
         someStub.restore();
       });`,
-      parserOptions: { ecmaVersion: 6 },
-      globals: ['it'],
+      parserOptions,
       errors: [
         {
           message: "Call 'ajaxSpy.restore()' before 'expect'",
@@ -181,8 +170,7 @@ ruleTester.run('no-unrestored-sinon-before-expect', rule, {
         expect(true).to.equal(true);
         ajaxSpy.restore();
       });`,
-      parserOptions: { ecmaVersion: 6 },
-      globals: ['it'],
+      parserOptions,
       errors: [
         {
           message: "Call 'ajaxSpy.restore()' before 'expect'",
@@ -199,8 +187,7 @@ ruleTester.run('no-unrestored-sinon-before-expect', rule, {
         afterEach(() => {
         });
       });`,
-      parserOptions: { ecmaVersion: 6 },
-      globals: ['it'],
+      parserOptions,
       errors: [
         {
           message: "Call 'spy.restore()' in an 'afterEach' block",
@@ -219,8 +206,7 @@ ruleTester.run('no-unrestored-sinon-before-expect', rule, {
         expect(true).to.equal(true);
         ajaxSpy.restore();
       });`,
-      parserOptions: { ecmaVersion: 6 },
-      globals: ['it'],
+      parserOptions,
       errors: [
         {
           message: "Call 'ajaxSpy.restore()' before 'expect'",
@@ -241,8 +227,7 @@ ruleTester.run('no-unrestored-sinon-before-expect', rule, {
           expect(stub.callCount).to.equal(1);
         });
       });`,
-      parserOptions: { ecmaVersion: 6 },
-      globals: ['it'],
+      parserOptions,
       errors: [
         {
           message: "Call 'spy.restore()' in an 'afterEach' block",

--- a/tests/lib/rules/no-unrestored-sinon-before-expect.js
+++ b/tests/lib/rules/no-unrestored-sinon-before-expect.js
@@ -88,6 +88,25 @@ ruleTester.run('no-unrestored-sinon-before-expect', rule, {
       parserOptions: { ecmaVersion: 6 },
       globals: ['it'],
     },
+    {
+      code: `describe("passes with hooks and it block", function() {
+        let spy;
+        beforeEach(() => {
+          spy = sinon.spy(someHelper, 'someMethod');
+        });
+        afterEach(() => {
+          spy.restore();
+        });
+        it("passes", () => {
+          const stub = sinon.stub(helper, 'method');
+          stub();
+          stub.restore();
+          expect(stub.called).to.equal(true);
+        })
+      });`,
+      parserOptions: { ecmaVersion: 6 },
+      globals: ['it'],
+    },
   ],
 
   invalid: [
@@ -184,8 +203,8 @@ ruleTester.run('no-unrestored-sinon-before-expect', rule, {
       globals: ['it'],
       errors: [
         {
-          message: "Call 'ajaxSpy.restore()' before 'expect'",
-          type: 'CallExpression',
+          message: "Call 'spy.restore()' in an 'afterEach' block",
+          type: 'ArrowFunctionExpression',
         },
       ],
     },
@@ -205,6 +224,32 @@ ruleTester.run('no-unrestored-sinon-before-expect', rule, {
       errors: [
         {
           message: "Call 'ajaxSpy.restore()' before 'expect'",
+          type: 'CallExpression',
+        },
+      ],
+    },
+    {
+      code: `describe("it should report from hooks and it blocks", function() {
+        let spy;
+        beforeEach(() => {
+          spy = sinon.spy(someHelper, 'someMethod');
+        });
+        afterEach(() => {
+        });
+        it("fails here too", () => {
+          const stub = sinon.stub(myHelper, 'someMethod');
+          expect(stub.callCount).to.equal(1);
+        });
+      });`,
+      parserOptions: { ecmaVersion: 6 },
+      globals: ['it'],
+      errors: [
+        {
+          message: "Call 'spy.restore()' in an 'afterEach' block",
+          type: 'ArrowFunctionExpression',
+        },
+        {
+          message: "Call 'stub.restore()' before 'expect'",
           type: 'CallExpression',
         },
       ],

--- a/tests/lib/rules/no-unrestored-sinon-before-expect.js
+++ b/tests/lib/rules/no-unrestored-sinon-before-expect.js
@@ -75,6 +75,19 @@ ruleTester.run('no-unrestored-sinon-before-expect', rule, {
       parserOptions: { ecmaVersion: 6 },
       globals: ['it'],
     },
+    {
+      code: `describe("passing case with before/after hooks", function() {
+        let spy;
+        beforeEach(() => {
+          spy = sinon.spy(someHelper, 'someMethod');
+        });
+        afterEach(() => {
+          spy.restore();
+        });
+      });`,
+      parserOptions: { ecmaVersion: 6 },
+      globals: ['it'],
+    },
   ],
 
   invalid: [
@@ -148,6 +161,24 @@ ruleTester.run('no-unrestored-sinon-before-expect', rule, {
         anotherSpy.restore();
         expect(true).to.equal(true);
         ajaxSpy.restore();
+      });`,
+      parserOptions: { ecmaVersion: 6 },
+      globals: ['it'],
+      errors: [
+        {
+          message: "Call 'ajaxSpy.restore()' before 'expect'",
+          type: 'CallExpression',
+        },
+      ],
+    },
+    {
+      code: `describe("failing case with before/after hooks", function() {
+        let spy;
+        beforeEach(() => {
+          spy = sinon.spy(someHelper, 'someMethod');
+        });
+        afterEach(() => {
+        });
       });`,
       parserOptions: { ecmaVersion: 6 },
       globals: ['it'],


### PR DESCRIPTION
Closes #7

Doesn't lint plain `before/after` hooks (without the `Each`), but the chance of stubbing something in those is low enough that I'd rather add that if it's needed.