### PR TITLE
Update for sinon calls fake

### DIFF
--- a/lib/rules/no-unrestored-sinon-before-expect.js
+++ b/lib/rules/no-unrestored-sinon-before-expect.js
@@ -55,6 +55,19 @@ module.exports = {
         DANGEROUS_SINON_METHODS.includes(variableDeclarer.init.callee.property.name)
       ) {
         dangerousSinonInstances[variableDeclarer.id.name] = true;
+      } else if (
+        // support for sinon.stub.callsFake
+        variableDeclarer.init.type === 'CallExpression' &&
+        variableDeclarer.init.callee &&
+        variableDeclarer.init.callee.type === 'MemberExpression' &&
+        variableDeclarer.init.callee.object &&
+        variableDeclarer.init.callee.object.callee &&
+        variableDeclarer.init.callee.object.callee.object &&
+        variableDeclarer.init.callee.object.callee.object.name === 'sinon' &&
+        DANGEROUS_SINON_METHODS.includes(variableDeclarer.init.callee.object.callee.property.name)
+
+      ) {
+        dangerousSinonInstances[variableDeclarer.id.name] = true;
       }
     }
 

--- a/tests/lib/rules/no-unrestored-sinon-before-expect.js
+++ b/tests/lib/rules/no-unrestored-sinon-before-expect.js
@@ -242,14 +242,14 @@ ruleTester.run('no-unrestored-sinon-before-expect', rule, {
     {
       code: `describe("it should report when sinon.callsFake is used", function() {
         it("fails here too", () => {
-          const stub = sinon.stub(myHelper, 'someMethod').callsFake(() => {});
+          const helperStub = sinon.stub(myHelper, 'someMethod').callsFake(() => {});
           expect(stub.callCount).to.equal(1);
         });
       });`,
       parserOptions,
       errors: [
         {
-          message: "Call 'stub.restore()' before 'expect'",
+          message: "Call 'helperStub.restore()' before 'expect'",
           type: 'CallExpression',
         },
       ],

--- a/tests/lib/rules/no-unrestored-sinon-before-expect.js
+++ b/tests/lib/rules/no-unrestored-sinon-before-expect.js
@@ -239,5 +239,20 @@ ruleTester.run('no-unrestored-sinon-before-expect', rule, {
         },
       ],
     },
+    {
+      code: `describe("it should report when sinon.callsFake is used", function() {
+        it("fails here too", () => {
+          const stub = sinon.stub(myHelper, 'someMethod').callsFake(() => {});
+          expect(stub.callCount).to.equal(1);
+        });
+      });`,
+      parserOptions,
+      errors: [
+        {
+          message: "Call 'stub.restore()' before 'expect'",
+          type: 'CallExpression',
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
`sinon.stub(Foo, 'bar').callsFake(() => doStuff());` has a different AST than the old `sinon.stub(Foo, 'bar', () => doStuff());` and wasn't warning about unrestored stubs. This updates the rule to support the new sinon syntax.