### PR TITLE
Add enzyme find with constructors rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Then configure the rules you want to use under the rules section.
 ## Supported Rules
 
 * [no-unstubbed-sinon-before-expect](docs/rules/no-unstubbed-sinon-before-expect.md)
+* [enzyme-find-constructors-only](docs/rules/enzyme-find-constructors-only.md)
 
 ## Adding a Rule
 

--- a/docs/rules/enzyme-find-constructors-only.md
+++ b/docs/rules/enzyme-find-constructors-only.md
@@ -3,6 +3,9 @@
 Enforce the use of a constructor with Enzyme's `.find` because
 it's faster and doesn't rely on `component.displayName`.
 
+Makes the wild assumption that all react components have an initial capital
+letter.
+
 
 ## Rule Details
 

--- a/docs/rules/enzyme-find-constructors-only.md
+++ b/docs/rules/enzyme-find-constructors-only.md
@@ -1,0 +1,36 @@
+# Only use constructors with enzyme .find (enzyme-find-constructors-only)
+
+Please describe the origin of the rule here.
+
+
+## Rule Details
+
+This rule aims to...
+
+Examples of **incorrect** code for this rule:
+
+```js
+
+// fill me in
+
+```
+
+Examples of **correct** code for this rule:
+
+```js
+
+// fill me in
+
+```
+
+### Options
+
+If there are any options, describe them here. Otherwise, delete this section.
+
+## When Not To Use It
+
+Give a short description of when it would be appropriate to turn off this rule.
+
+## Further Reading
+
+If there are other links that describe the issue this rule addresses, please include them here in a bulleted list.

--- a/docs/rules/enzyme-find-constructors-only.md
+++ b/docs/rules/enzyme-find-constructors-only.md
@@ -1,36 +1,30 @@
 # Only use constructors with enzyme .find (enzyme-find-constructors-only)
 
-Please describe the origin of the rule here.
+Enforce the use of a constructor with Enzyme's `.find` because
+it's faster and doesn't rely on `component.displayName`.
 
 
 ## Rule Details
 
-This rule aims to...
-
 Examples of **incorrect** code for this rule:
 
 ```js
-
-// fill me in
-
+const avatar = wrapper.find('Avatar');
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
+import Avatar from '../Avatar';
 
-// fill me in
-
+const avatar = wrapper.find(Avatar);
 ```
 
-### Options
+## Usage with connected components
 
-If there are any options, describe them here. Otherwise, delete this section.
+Strings with `'Connect'` are whitelisted for usage with redux connected
+components:
 
-## When Not To Use It
-
-Give a short description of when it would be appropriate to turn off this rule.
-
-## Further Reading
-
-If there are other links that describe the issue this rule addresses, please include them here in a bulleted list.
+```js
+const avatar = wrapper.find('Connect(Avatar)');
+```

--- a/lib/rules/enzyme-find-constructors-only.js
+++ b/lib/rules/enzyme-find-constructors-only.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview Only use constructors with enzyme .find
- * @author evan
+ * @author Evan Lloyd
  */
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/lib/rules/enzyme-find-constructors-only.js
+++ b/lib/rules/enzyme-find-constructors-only.js
@@ -2,8 +2,6 @@
  * @fileoverview Only use constructors with enzyme .find
  * @author evan
  */
-"use strict";
-
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -11,18 +9,17 @@
 module.exports = {
   meta: {
     docs: {
-      description: "Only use constructors with enzyme .find",
-      category: "Fill me in",
-      recommended: false
+      description: 'Only use constructors with enzyme .find',
+      category: 'react-testing',
+      recommended: false,
     },
     fixable: null,  // or "code" or "whitespace"
     schema: [
       // fill in your schema
-    ]
+    ],
   },
 
-  create: function(context) {
-
+  create: function create(context) {
     // variables should be defined here
     // if the args to find includes one of these, it should be okay
     const WHITELISTED_STRINGS = ['Connect'];
@@ -34,9 +31,7 @@ module.exports = {
     // any helper functions should go here or else delete this section
     //
     function isWhitelisted(string) {
-      return WHITELISTED_STRINGS.some((whitelisted) => {
-        return string.includes(whitelisted);
-      });
+      return WHITELISTED_STRINGS.some((whitelisted) => string.includes(whitelisted));
     }
 
     //----------------------------------------------------------------------
@@ -52,17 +47,13 @@ module.exports = {
           // needs a guard on presence
           if (argToFind.type === 'Literal' && !isWhitelisted(argToFind.value)) {
             return context.report({
-              node: node,
+              node,
               message: 'Please use a constructor with `find`, not a string literal',
             });
           }
-
         }
-        return;
-      }
-
-      // give me methods
-
+        return null;
+      },
     };
-  }
+  },
 };

--- a/lib/rules/enzyme-find-constructors-only.js
+++ b/lib/rules/enzyme-find-constructors-only.js
@@ -1,0 +1,62 @@
+/**
+ * @fileoverview Only use constructors with enzyme .find
+ * @author evan
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: "Only use constructors with enzyme .find",
+      category: "Fill me in",
+      recommended: false
+    },
+    fixable: null,  // or "code" or "whitespace"
+    schema: [
+      // fill in your schema
+    ]
+  },
+
+  create: function(context) {
+
+    // variables should be defined here
+    // if the args to find includes one of these, it should be okay
+    const whitelistedStrings = ['Connect'];
+
+    //----------------------------------------------------------------------
+    // Helpers
+    //----------------------------------------------------------------------
+
+    // any helper functions should go here or else delete this section
+
+    //----------------------------------------------------------------------
+    // Public
+    //----------------------------------------------------------------------
+
+    return {
+      CallExpression: (node) => {
+        if (node.callee && node.callee.property && node.callee.property.name === 'find') {
+          // look at the args
+          const args = node.arguments;
+          const argToFind = args[0];
+          // needs a guard on presence
+          if (argToFind.type === 'Literal') {
+            return context.report({
+              node: node,
+              message: 'Please use a constructor with `find`, not a string literal',
+            });
+          }
+
+        }
+        return;
+      }
+
+      // give me methods
+
+    };
+  }
+};

--- a/lib/rules/enzyme-find-constructors-only.js
+++ b/lib/rules/enzyme-find-constructors-only.js
@@ -25,13 +25,19 @@ module.exports = {
 
     // variables should be defined here
     // if the args to find includes one of these, it should be okay
-    const whitelistedStrings = ['Connect'];
+    const WHITELISTED_STRINGS = ['Connect'];
 
     //----------------------------------------------------------------------
     // Helpers
     //----------------------------------------------------------------------
 
     // any helper functions should go here or else delete this section
+    //
+    function isWhitelisted(string) {
+      return WHITELISTED_STRINGS.some((whitelisted) => {
+        return string.includes(whitelisted);
+      });
+    }
 
     //----------------------------------------------------------------------
     // Public
@@ -44,7 +50,7 @@ module.exports = {
           const args = node.arguments;
           const argToFind = args[0];
           // needs a guard on presence
-          if (argToFind.type === 'Literal') {
+          if (argToFind.type === 'Literal' && !isWhitelisted(argToFind.value)) {
             return context.report({
               node: node,
               message: 'Please use a constructor with `find`, not a string literal',

--- a/lib/rules/enzyme-find-constructors-only.js
+++ b/lib/rules/enzyme-find-constructors-only.js
@@ -34,6 +34,13 @@ module.exports = {
       return WHITELISTED_STRINGS.some((whitelisted) => string.includes(whitelisted));
     }
 
+    function reportError({ node, stringLiteral }) {
+      return context.report({
+        node,
+        message: `Please use a constructor with 'find': 'find(${stringLiteral})', not a string`,
+      });
+    }
+
     //----------------------------------------------------------------------
     // Public
     //----------------------------------------------------------------------
@@ -41,14 +48,13 @@ module.exports = {
     return {
       CallExpression: (node) => {
         if (node.callee && node.callee.property && node.callee.property.name === 'find') {
-          // look at the args
           const args = node.arguments;
-          const argToFind = args[0];
-          // needs a guard on presence
+          const argToFind = args[0] || {};
+
           if (argToFind.type === 'Literal' && !isWhitelisted(argToFind.value)) {
-            return context.report({
+            return reportError({
               node,
-              message: 'Please use a constructor with `find`, not a string literal',
+              stringLiteral: argToFind.value,
             });
           }
         }

--- a/lib/rules/enzyme-find-constructors-only.js
+++ b/lib/rules/enzyme-find-constructors-only.js
@@ -13,14 +13,11 @@ module.exports = {
       category: 'react-testing',
       recommended: false,
     },
-    fixable: null,  // or "code" or "whitespace"
-    schema: [
-      // fill in your schema
-    ],
+    fixable: 'code',  // or "code" or "whitespace"
+    schema: [], // no options
   },
 
   create: function create(context) {
-    // variables should be defined here
     // if the args to find includes one of these, it should be okay
     const WHITELISTED_STRINGS = ['Connect'];
 
@@ -28,10 +25,14 @@ module.exports = {
     // Helpers
     //----------------------------------------------------------------------
 
-    // any helper functions should go here or else delete this section
-    //
     function isWhitelisted(string) {
       return WHITELISTED_STRINGS.some((whitelisted) => string.includes(whitelisted));
+    }
+
+    function hasInitialCapital(string) {
+      const firstChar = string[0];
+
+      return firstChar != firstChar.toLowerCase() && firstChar == firstChar.toUpperCase();
     }
 
     function reportError({ node, stringLiteral }) {
@@ -50,11 +51,12 @@ module.exports = {
         if (node.callee && node.callee.property && node.callee.property.name === 'find') {
           const args = node.arguments;
           const argToFind = args[0] || {};
+          const { value } = argToFind;
 
-          if (argToFind.type === 'Literal' && !isWhitelisted(argToFind.value)) {
+          if (argToFind.type === 'Literal' && hasInitialCapital(value) && !isWhitelisted(value)) {
             return reportError({
               node,
-              stringLiteral: argToFind.value,
+              stringLiteral: value,
             });
           }
         }

--- a/tests/lib/rules/enzyme-find-constructors-only.js
+++ b/tests/lib/rules/enzyme-find-constructors-only.js
@@ -10,7 +10,7 @@
 
 var rule = require("../../../lib/rules/enzyme-find-constructors-only"),
 
-    RuleTester = require("eslint").RuleTester;
+  RuleTester = require("eslint").RuleTester;
 
 
 //------------------------------------------------------------------------------
@@ -21,19 +21,29 @@ const parserOptions = { ecmaVersion: 6 };
 const ruleTester = new RuleTester();
 ruleTester.run("enzyme-find-constructors-only", rule, {
 
-    valid: [
+  valid: [
+    {
+      code: 'const child = wrapper.find(Link)',
+      parserOptions,
+    },
+    {
+      code: 'let child = wrapper.find(Link)',
+      parserOptions,
+    },
+    {
+      code: "let child = wrapper.find('Connect(Link)')",
+      parserOptions,
+    },
+  ],
 
-        // give me some code that won't trigger a warning
-    ],
-
-    invalid: [
-        {
-            code: "const child = wrapper.find('Link');",
-            parserOptions,
-            errors: [{
-                message: "Please use a constructor with `find`, not a string literal",
-                type: "CallExpression"
-            }]
-        }
-    ]
+  invalid: [
+    {
+      code: "const child = wrapper.find('Link');",
+      parserOptions,
+      errors: [{
+        message: "Please use a constructor with `find`, not a string literal",
+        type: "CallExpression"
+      }]
+    }
+  ]
 });

--- a/tests/lib/rules/enzyme-find-constructors-only.js
+++ b/tests/lib/rules/enzyme-find-constructors-only.js
@@ -43,7 +43,7 @@ ruleTester.run('enzyme-find-constructors-only', rule, {
       code: "const child = wrapper.find('Link');",
       parserOptions,
       errors: [{
-        message: 'Please use a constructor with `find`, not a string literal',
+        message: "Please use a constructor with 'find': 'find(Link)', not a string",
         type: 'CallExpression',
       }],
     },

--- a/tests/lib/rules/enzyme-find-constructors-only.js
+++ b/tests/lib/rules/enzyme-find-constructors-only.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview Only use constructors with enzyme .find
- * @author evan
+ * @author Evan Lloyd
  */
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/enzyme-find-constructors-only.js
+++ b/tests/lib/rules/enzyme-find-constructors-only.js
@@ -34,6 +34,10 @@ ruleTester.run("enzyme-find-constructors-only", rule, {
       code: "let child = wrapper.find('Connect(Link)')",
       parserOptions,
     },
+    {
+      code: "let child = [1, 2].find(isEven)",
+      parserOptions,
+    },
   ],
 
   invalid: [

--- a/tests/lib/rules/enzyme-find-constructors-only.js
+++ b/tests/lib/rules/enzyme-find-constructors-only.js
@@ -1,0 +1,39 @@
+/**
+ * @fileoverview Only use constructors with enzyme .find
+ * @author evan
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/rules/enzyme-find-constructors-only"),
+
+    RuleTester = require("eslint").RuleTester;
+
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const parserOptions = { ecmaVersion: 6 };
+const ruleTester = new RuleTester();
+ruleTester.run("enzyme-find-constructors-only", rule, {
+
+    valid: [
+
+        // give me some code that won't trigger a warning
+    ],
+
+    invalid: [
+        {
+            code: "const child = wrapper.find('Link');",
+            parserOptions,
+            errors: [{
+                message: "Please use a constructor with `find`, not a string literal",
+                type: "CallExpression"
+            }]
+        }
+    ]
+});

--- a/tests/lib/rules/enzyme-find-constructors-only.js
+++ b/tests/lib/rules/enzyme-find-constructors-only.js
@@ -36,6 +36,18 @@ ruleTester.run('enzyme-find-constructors-only', rule, {
       code: 'let child = [1, 2].find(isEven)',
       parserOptions,
     },
+    {
+      code: "const component = wrapper.find('.some-class')",
+      parserOptions,
+    },
+    {
+      code: `const component = wrapper.find('input[type="submit"]');`,
+      parserOptions,
+    },
+    {
+      code: `const component = wrapper.find('h1');`,
+      parserOptions,
+    }
   ],
 
   invalid: [

--- a/tests/lib/rules/enzyme-find-constructors-only.js
+++ b/tests/lib/rules/enzyme-find-constructors-only.js
@@ -2,15 +2,13 @@
  * @fileoverview Only use constructors with enzyme .find
  * @author evan
  */
-"use strict";
 
 //------------------------------------------------------------------------------
 // Requirements
 //------------------------------------------------------------------------------
 
-var rule = require("../../../lib/rules/enzyme-find-constructors-only"),
-
-  RuleTester = require("eslint").RuleTester;
+const rule = require('../../../lib/rules/enzyme-find-constructors-only');
+const RuleTester = require('eslint').RuleTester;
 
 
 //------------------------------------------------------------------------------
@@ -19,7 +17,7 @@ var rule = require("../../../lib/rules/enzyme-find-constructors-only"),
 
 const parserOptions = { ecmaVersion: 6 };
 const ruleTester = new RuleTester();
-ruleTester.run("enzyme-find-constructors-only", rule, {
+ruleTester.run('enzyme-find-constructors-only', rule, {
 
   valid: [
     {
@@ -35,7 +33,7 @@ ruleTester.run("enzyme-find-constructors-only", rule, {
       parserOptions,
     },
     {
-      code: "let child = [1, 2].find(isEven)",
+      code: 'let child = [1, 2].find(isEven)',
       parserOptions,
     },
   ],
@@ -45,9 +43,9 @@ ruleTester.run("enzyme-find-constructors-only", rule, {
       code: "const child = wrapper.find('Link');",
       parserOptions,
       errors: [{
-        message: "Please use a constructor with `find`, not a string literal",
-        type: "CallExpression"
-      }]
-    }
-  ]
+        message: 'Please use a constructor with `find`, not a string literal',
+        type: 'CallExpression',
+      }],
+    },
+  ],
 });


### PR DESCRIPTION
enforce component constructors with enzyme `.find` except when whitelisted, like with `'Connect(MyComponent)'` because it's faster. Assumes react components start with a capital letter.

![screen shot 2018-03-05 at 2 33 57 pm](https://user-images.githubusercontent.com/5827130/36995532-47d83636-2082-11e8-92c5-340bdff34834.png)
